### PR TITLE
Changes in style.css to remove white space appearing on the right side of pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,10 @@
     line-height: 180%;
     font-size: 16px;
 }
+html, body{
+    width: 100%;
+    overflow-x: hidden;
+}
 html{
     scroll-behavior: smooth;
 }


### PR DESCRIPTION
The webpages were not covering the entire screen size, a white space was appearing on changing the device size. Resolved by changing the width to 100% and by making overflow-x hidden.